### PR TITLE
Bump: Moesif.Api dependency to 1.1.5

### DIFF
--- a/Moesif.Middleware/Moesif.Middleware.csproj
+++ b/Moesif.Middleware/Moesif.Middleware.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moesif.Api" Version="1.1.4" />
+    <PackageReference Include="Moesif.Api" Version="1.1.5" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/Moesif.Middleware/Moesif.Middleware.nuspec
+++ b/Moesif.Middleware/Moesif.Middleware.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Moesif.Middleware</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>MoesifMiddleware</title>
     <authors>Moesif</authors>
 	  <owners>Moesif</owners>
@@ -17,11 +17,12 @@
     <language>en-US</language>
     <tags>moesif restful rest graphql web3 api analytics log logging error debug</tags>
 	<dependencies>
-    <dependency id="Moesif.Api" version="1.1.4" />
+    <dependency id="Moesif.Api" version="1.1.5" />
 	</dependencies>
   </metadata>
   <files>
     <file src="bin\Release\netstandard2.0\Moesif.Middleware.dll" target="lib\Moesif.Middleware.dll" />
+    <file src="bin\Release\net461\Moesif.Middleware.dll" target="lib\Moesif.Middleware.dll" />
     <file src="..\README.md" target="readme.txt" />
     <file src="..\LICENSE" target="LICENSE" />
   </files>

--- a/Moesif.Middleware/Properties/AssemblyInfo.cs
+++ b/Moesif.Middleware/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0")]
+[assembly: AssemblyVersion("1.0.1")]
+[assembly: AssemblyFileVersion("1.0.1")]

--- a/Moesif.Middleware/packages.config
+++ b/Moesif.Middleware/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net461" />
   <package id="Microsoft.Owin" version="4.0.1" targetFramework="net461" />
-  <package id="Moesif.Api" version="1.1.4" targetFramework="net461" />
+  <package id="Moesif.Api" version="1.1.5" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="Unirest-APIMATIC" version="1.0.1.27" targetFramework="net461" />

--- a/Moesif.NetFramework.Test/Moesif.NetFramework.Test.csproj
+++ b/Moesif.NetFramework.Test/Moesif.NetFramework.Test.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Moesif.NetFramework.Test</RootNamespace>
     <AssemblyName>Moesif.NetFramework.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Bump: Moesif.Api dependency to 1.1.5
Fix: Nuspec targeting multiple framework
Refactor: Change Net Framework target to 4.6.1
Bump version to 1.0.1