### PR TITLE
Fix: Req body rewind errors,

### DIFF
--- a/Moesif.Middleware/MoesifMiddleware.cs
+++ b/Moesif.Middleware/MoesifMiddleware.cs
@@ -26,8 +26,14 @@ namespace Moesif.Middleware
 
         public MoesifMiddleware(Dictionary<string, object> _middleware) => netCoreMoesifMiddleware = new MoesifMiddlewareNetCore(_middleware);
 
-        public async Task Invoke(HttpContext httpContext) {
-            await netCoreMoesifMiddleware.Invoke(httpContext);
+        public async Task Invoke(HttpContext httpContext) 
+        {
+            try
+            {
+                await netCoreMoesifMiddleware.Invoke(httpContext);
+            }
+            catch 
+            { }
         }
 
         // Function to update user
@@ -71,7 +77,12 @@ namespace Moesif.Middleware
 
         public async override Task Invoke(IOwinContext httpContext)
         {
-            await netFrameworkMoesifMiddleware.Invoke(httpContext);
+            try 
+            {
+                await netFrameworkMoesifMiddleware.Invoke(httpContext);
+            }
+            catch 
+            { }
         }
 
         // Function to update user

--- a/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
+++ b/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
@@ -349,6 +349,10 @@ namespace Moesif.Middleware.NetCore
                         Console.WriteLine("Can not execute IdentifyUser function. Please check moesif settings.");
                     }
                 }
+                else 
+                {
+                    userId = httpContext?.User?.Identity?.Name;
+                }
 
                 // CompanyId
                 var company_out = new object();


### PR DESCRIPTION
- Ensure don't seek unseekable stream and instead create memorystream
- Fix header parsing when duplicate keys
- Don't fail if HttpContext.Current is not injected due to not using IIS
- Read Current Identity
- 1.1.6