### PR TITLE
#186365985 : Update governance rule

### DIFF
--- a/Moesif.Middleware/Helpers/AppConfigHelper.cs
+++ b/Moesif.Middleware/Helpers/AppConfigHelper.cs
@@ -63,7 +63,7 @@ namespace Moesif.Middleware.Helpers
                     {
                         if (requestMap.regex_mapping.ContainsKey(c.path))
                         {
-                            Match m = Regex.Match(requestMap.regex_mapping[c.path], c.value, RegexOptions.IgnoreCase);
+                            Match m = Regex.Match((string)requestMap.regex_mapping[c.path], c.value, RegexOptions.IgnoreCase);
                             if (!m.Success)
                             {
                                 matched = false;

--- a/Moesif.Middleware/Helpers/GovernanceHelper.cs
+++ b/Moesif.Middleware/Helpers/GovernanceHelper.cs
@@ -143,38 +143,6 @@ namespace Moesif.Middleware.Helpers
             });
         }
 
-        //static void updateEventModel(EventModel eventModel, Rule rule, GovernanceRule governanceRule)
-        //{
-        //    var response = governanceRule.response;
-        //    if(rule == null)
-        //    {
-        //        updateEventModel(eventModel, governanceRule.response, governanceRule._id);
-        //        return;
-        //    }
-        //    var headers = response.headers;
-        //    headers ??= new Dictionary<string, string>();
-        //    var variables = rule.values?.ToDictionary(kv => $"{{{{{kv.Key}}}}}", kv => kv.Value);
-        //    variables ??= new Dictionary<string, string>();
-        //    response.headers = headers.ToDictionary(kv => kv.Key, kv =>
-        //    {
-        //        var value = kv.Value;
-        //        foreach (var v in variables)
-        //        {
-        //            value = value.Replace(v.Key, v.Value);
-        //        }
-        //        return value;
-        //    });
-
-        //    var body = response.body.ToString();
-        //    foreach (var v in variables)
-        //    {
-        //        body = body.Replace(v.Key, v.Value);
-        //    }
-        //    response.body = body;
-
-        //    updateEventModel(eventModel, response, governanceRule._id);
-
-        //}
 
         static void updateEventModel(EventModel eventModel, Response response, string ruleId)
         {
@@ -224,8 +192,6 @@ namespace Moesif.Middleware.Helpers
                                 Match m = Regex.Match(fieldlValue.ToString(), c.value, RegexOptions.IgnoreCase);
                                 if (!m.Success)
                                 {
-                                    //matched = false;
-                                    //break;
                                     return false;
                                 }
                                 else
@@ -235,8 +201,6 @@ namespace Moesif.Middleware.Helpers
                             }
                             else
                             {
-                                //matched = false;
-                                //break;
                                 return false;
                             }
 
@@ -314,7 +278,6 @@ namespace Moesif.Middleware.Helpers
                             }
                         }
                     }
-                    //return matching;
                 }
                 else
                 {
@@ -329,7 +292,6 @@ namespace Moesif.Middleware.Helpers
                             }
                         }
                     }
-                    //return matching;
                 }
 
             }

--- a/Moesif.Middleware/Helpers/RequestMapHelper.cs
+++ b/Moesif.Middleware/Helpers/RequestMapHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Moesif.Api.Models;
 using Moesif.Middleware.Models;
+using System;
 using System.Text.RegularExpressions;
 namespace Moesif.Middleware.Helpers
 {
@@ -16,7 +17,7 @@ namespace Moesif.Middleware.Helpers
             {
                 companyId = model.CompanyId,
                 userId = model.UserId,
-                regex_mapping = new System.Collections.Generic.Dictionary<string, string>()
+                regex_mapping = new System.Collections.Generic.Dictionary<string, object>()
             };
             if (model.Request.Verb != null)
             {
@@ -28,9 +29,12 @@ namespace Moesif.Middleware.Helpers
             }
             if (model.Request.Uri != null)
             {
-                Match m = Regex.Match(model.Request.Uri, "http[s]?://[^/]+(/[^?]+)", RegexOptions.IgnoreCase);
                 var route = "/";
-                if (m.Groups.Count == 2) route = m.Groups[1].Value;
+                try
+                {
+                    route = new System.Uri(model.Request.Uri).LocalPath;
+                }
+                catch (Exception) { }
                 requestMap.regex_mapping.Add("request.route", route);
             }
             if (model.Response != null)
@@ -54,6 +58,7 @@ namespace Moesif.Middleware.Helpers
                 {
                     requestMap.regex_mapping.Add("request.body.query", query.ToString());
                 }
+                requestMap.regex_mapping.Add("request.body", body);
             }
 
             return requestMap;

--- a/Moesif.Middleware/Models/Governance.cs
+++ b/Moesif.Middleware/Models/Governance.cs
@@ -35,6 +35,8 @@ namespace Moesif.Middleware.Models
         public List<RegexConfig> regex_config { get; set; }
         public List<Variable> variables { get; set; }
         public Response response { get; set; }
+        public bool applied_to_unidentified { get; set; }
+        public string applied_to { get; set; }
 
     }
 

--- a/Moesif.Middleware/Models/RequestMap.cs
+++ b/Moesif.Middleware/Models/RequestMap.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Path = System.String;
-using Value = System.String;
+using Value = System.Object;
 
 namespace Moesif.Middleware.Models
 {

--- a/Moesif.Middleware/Moesif.Middleware.nuspec
+++ b/Moesif.Middleware/Moesif.Middleware.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Moesif.Middleware</id>
-    <version>1.4.00</version>
+    <version>1.4.1</version>
     <title>MoesifMiddleware</title>
     <authors>Moesif</authors>
 	  <owners>Moesif</owners>

--- a/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
+++ b/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
@@ -81,7 +81,7 @@ public DateTime lastWorkerRun = DateTime.MinValue;
             try
             {
                 // Initialize client
-                client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString());
+                client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString(), "moesif-netcore/1.4.1", debug);
                 debug = loggerHelper.GetConfigBoolValues(moesifOptions, "LocalDebug", false);
                 companyHelper = new CompanyHelper();
                 userHelper = new UserHelper();
@@ -102,7 +102,7 @@ public DateTime lastWorkerRun = DateTime.MinValue;
             {
                 // Initialize client
                 debug = loggerHelper.GetConfigBoolValues(moesifOptions, "LocalDebug", false);
-                client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString(), "moesif-netcore/1.3.26", debug);
+                client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString(), "moesif-netcore/1.4.1", debug);
                 logBody = loggerHelper.GetConfigBoolValues(moesifOptions, "LogBody", true);
                 _next = next;
                 config = AppConfig.getDefaultAppConfig();
@@ -110,8 +110,8 @@ public DateTime lastWorkerRun = DateTime.MinValue;
                 companyHelper = new CompanyHelper(); // Create a new instane of companyHelper
                 clientIpHelper = new ClientIp(); // Create a new instance of client Ip
                 isBatchingEnabled = loggerHelper.GetConfigBoolValues(moesifOptions, "EnableBatching", true); // Enable batching
-                batchSize = loggerHelper.GetConfigIntValues(moesifOptions, "BatchSize", 25); // Batch Size
-                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 1000); // Queue Size
+                batchSize = loggerHelper.GetConfigIntValues(moesifOptions, "BatchSize", 200); // Batch Size
+                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 100*1000); // Queue Size
                 batchMaxTime = loggerHelper.GetConfigIntValues(moesifOptions, "batchMaxTime", 2); // Batch max time in seconds
                 appConfigSyncTime = loggerHelper.GetConfigIntValues(moesifOptions, "appConfigSyncTime", 300); // App config sync time in seconds
                 authorizationHeaderName = loggerHelper.GetConfigStringValues(moesifOptions, "AuthorizationHeaderName", "authorization");
@@ -517,6 +517,10 @@ public DateTime lastWorkerRun = DateTime.MinValue;
                     _logger.LogWarning("Unauthorized access sending event to Moesif. Please check your Appplication Id.");
                 }
                 _logger.LogWarning("Error sending event to Moesif, with status code: {statusCode}", inst.ResponseCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception in sending event");
             }
         }
 

--- a/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
+++ b/Moesif.Middleware/NetCore/MoesifMiddlewareNetCore.cs
@@ -56,7 +56,7 @@ namespace Moesif.Middleware.NetCore
 
         public string authorizationUserIdField; // A field name used to parse the User from authorization header
 
-public DateTime lastWorkerRun = DateTime.MinValue;
+        public DateTime lastWorkerRun = DateTime.MinValue;
 
         public DateTime lastAppConfigWorkerRun = DateTime.MinValue;
 
@@ -111,7 +111,7 @@ public DateTime lastWorkerRun = DateTime.MinValue;
                 clientIpHelper = new ClientIp(); // Create a new instance of client Ip
                 isBatchingEnabled = loggerHelper.GetConfigBoolValues(moesifOptions, "EnableBatching", true); // Enable batching
                 batchSize = loggerHelper.GetConfigIntValues(moesifOptions, "BatchSize", 200); // Batch Size
-                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 100*1000); // Queue Size
+                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 100 * 1000); // Queue Size
                 batchMaxTime = loggerHelper.GetConfigIntValues(moesifOptions, "batchMaxTime", 2); // Batch max time in seconds
                 appConfigSyncTime = loggerHelper.GetConfigIntValues(moesifOptions, "appConfigSyncTime", 300); // App config sync time in seconds
                 authorizationHeaderName = loggerHelper.GetConfigStringValues(moesifOptions, "AuthorizationHeaderName", "authorization");
@@ -295,10 +295,7 @@ public DateTime lastWorkerRun = DateTime.MinValue;
                 }
                 await httpContext.Response.WriteAsync(eventModel.Response.Body.ToString());
 
-                if(debug)
-                {
-                    _logger.LogDebug("Request is blocked by Governance rule {ruleId}", eventModel.BlockedBy);
-                }
+                _logger.LogDebug("Request is blocked by Governance rule {ruleId}", eventModel.BlockedBy);
 
                 eventModel.Response.Headers["X-Moesif-Transaction-Id"] = transactionId;
                 if (!skipLogging)

--- a/Moesif.Middleware/NetFramework/MoesifMiddlewareNetFramework.cs
+++ b/Moesif.Middleware/NetFramework/MoesifMiddlewareNetFramework.cs
@@ -80,7 +80,7 @@ namespace Moesif.Middleware.NetFramework
             _logger = null;
             loggerHelper = new LoggerHelper(_logger);
             debug = loggerHelper.GetConfigBoolValues(moesifOptions, "LocalDebug", false);
-            client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString(), "moesif-netframework/1.3.25", debug);
+            client = new MoesifApiClient(moesifOptions["ApplicationId"].ToString(), "moesif-netframework/1.4.1", debug);
             userHelper = new UserHelper(); // Create a new instance of userHelper
             companyHelper = new CompanyHelper(); // Create a new instane of companyHelper
             clientIpHelper = new ClientIp(); // Create a new instance of client Ip
@@ -100,8 +100,8 @@ namespace Moesif.Middleware.NetFramework
                 logBody = loggerHelper.GetConfigBoolValues(moesifOptions, "LogBody", true);
                 isBatchingEnabled = loggerHelper.GetConfigBoolValues(moesifOptions, "EnableBatching", true); // Enable batching
                 disableStreamOverride = loggerHelper.GetConfigBoolValues(moesifOptions, "DisableStreamOverride", false); // Reset Request Body position
-                batchSize = loggerHelper.GetConfigIntValues(moesifOptions, "BatchSize", 25); // Batch Size
-                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 1000); // Event Queue Size
+                batchSize = loggerHelper.GetConfigIntValues(moesifOptions, "BatchSize", 200); // Batch Size
+                queueSize = loggerHelper.GetConfigIntValues(moesifOptions, "QueueSize", 100*1000); // Event Queue Size
                 batchMaxTime = loggerHelper.GetConfigIntValues(moesifOptions, "batchMaxTime", 2); // Batch max time in seconds
                 appConfigSyncTime = loggerHelper.GetConfigIntValues(moesifOptions, "appConfigSyncTime", 300); // App config sync time in seconds
                 config = AppConfig.getDefaultAppConfig();

--- a/Moesif.Middleware/Properties/AssemblyInfo.cs
+++ b/Moesif.Middleware/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.00")]
-[assembly: AssemblyFileVersion("1.4.00")]
+[assembly: AssemblyVersion("1.4.1")]
+[assembly: AssemblyFileVersion("1.4.1")]

--- a/Moesif.NetCore.Test/MoesifNetCoreTest.cs
+++ b/Moesif.NetCore.Test/MoesifNetCoreTest.cs
@@ -804,28 +804,6 @@ namespace Moesif.NetCore.Test
 
             Assert.AreEqual(GovernanceHelper.enforceGovernaceRule(eventModel, governace, appConfig), true);
 
-            eventReq = new EventRequestModel()
-            {
-                Time = DateTime.UtcNow,
-                Uri = "https://localhost:5001/api/Employee",
-                Verb = "GET",
-                ApiVersion = null,
-                IpAddress = "120.110.10.11",
-                Headers = new Dictionary<string, string>(),
-                Body = null,
-                TransferEncoding = null
-            };
-            eventModel = new EventModel()
-            {
-                Request = eventReq,
-                //CompanyId = "sean-company-11",
-                SessionToken = "xxxx",
-                Metadata = new Dictionary<string, string>(),
-                Direction = "Outgoing"
-            };
-
-            Assert.AreEqual(GovernanceHelper.enforceGovernaceRule(eventModel, governace, appConfig), true);
-
         }
 
     }


### PR DESCRIPTION


Pull Request review Checklist:
 - [x] `Follows` guidelines for `public` repo ?
 - [ ] `README` updated, if required ?
 - [x] `Release Version` updated ?
 - [x] `User Agent` Version updated ?
 - [x] `Includes` tests conducted and `test result` in the ticket and/or QA doc ?
 - [x] `Does NOT` include code from others?  (Unintended consequence of a bad merge) ?


npm run test:events

> governance-rules-tests@1.0.0 test:events /Users/xiaokanghuo/dev/governance-rules-tests
> cross-env RUN_TYPE=EVENTS mocha --require @babel/register

hereEVENTShttps://api.moesif.net


  Test sending events with rule from Case 1, apply to: matching, apply to unidentified: true
get error back altuog
Error: Forbidden
    at Request.callback (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:901:17)
    at IncomingMessage.<anonymous> (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:1166:18)
    at IncomingMessage.emit (events.js:412:35)
    at endReadableNT (internal/streams/readable.js:1333:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  status: 403,
  response: <ref *1> Response {
    _events: [Object: null prototype] {},
    _eventsCount: 0,
    _maxListeners: undefined,
    res: IncomingMessage {
      _readableState: [ReadableState],
      _events: [Object: null prototype],
      _eventsCount: 4,
      _maxListeners: undefined,
      socket: [Socket],
      httpVersionMajor: 1,
      httpVersionMinor: 1,
      httpVersion: '1.1',
      complete: true,
      headers: [Object],
      rawHeaders: [Array],
      trailers: {},
      rawTrailers: [],
      aborted: false,
      upgrade: false,
      url: '',
      method: null,
      statusCode: 403,
      statusMessage: 'Forbidden',
      client: [Socket],
      _consuming: true,
      _dumped: false,
      req: [ClientRequest],
      text: '{\n  "your_city": "rome",\n  "your_country": "italy"\n}',
      [Symbol(kCapture)]: false,
      [Symbol(RequestTimeout)]: undefined
    },
    request: Request {
      _events: [Object: null prototype],
      _eventsCount: 1,
      _maxListeners: undefined,
      _enableHttp2: false,
      _agent: false,
      _formData: null,
      method: 'GET',
      url: 'http://localhost:5001/gov/no_italy',
      _header: [Object],
      header: [Object],
      writable: true,
      _redirects: 0,
      _maxRedirects: 5,
      cookies: '',
      qs: {},
      _query: [],
      qsRaw: [],
      _redirectList: [],
      _streamRequest: false,
      _lookup: undefined,
      req: [ClientRequest],
      protocol: 'http:',
      host: 'localhost:5001',
      _endCalled: true,
      _callback: [Function (anonymous)],
      _fullfilledPromise: [Promise],
      res: [IncomingMessage],
      _resBuffered: true,
      response: [Circular *1],
      called: true,
      [Symbol(kCapture)]: false
    },
    req: ClientRequest {
      _events: [Object: null prototype],
      _eventsCount: 3,
      _maxListeners: undefined,
      outputData: [],
      outputSize: 0,
      writable: true,
      destroyed: false,
      _last: true,
      chunkedEncoding: false,
      shouldKeepAlive: false,
      _defaultKeepAlive: true,
      useChunkedEncodingByDefault: false,
      sendDate: false,
      _removedConnection: false,
      _removedContLen: false,
      _removedTE: false,
      _contentLength: 0,
      _hasBody: true,
      _trailer: '',
      finished: true,
      _headerSent: true,
      socket: [Socket],
      _header: 'GET /gov/no_italy HTTP/1.1\r\n' +
        'Host: localhost:5001\r\n' +
        'Accept-Encoding: gzip, deflate\r\n' +
        'X-User-Id: rome1\r\n' +
        'Connection: close\r\n' +
        '\r\n',
      _keepAliveTimeout: 0,
      _onPendingData: [Function: noopPendingOutput],
      agent: [Agent],
      socketPath: undefined,
      method: 'GET',
      maxHeaderSize: undefined,
      insecureHTTPParser: undefined,
      path: '/gov/no_italy',
      _ended: true,
      res: [IncomingMessage],
      aborted: false,
      timeoutCb: null,
      upgradeOrConnect: false,
      parser: null,
      maxHeadersCount: null,
      reusedSocket: false,
      host: 'localhost',
      protocol: 'http:',
      [Symbol(kCapture)]: false,
      [Symbol(kNeedDrain)]: false,
      [Symbol(corked)]: 0,
      [Symbol(kOutHeaders)]: [Object: null prototype]
    },
    text: '{\n  "your_city": "rome",\n  "your_country": "italy"\n}',
    files: undefined,
    buffered: true,
    headers: {
      connection: 'close',
      date: 'Thu, 02 Nov 2023 22:51:17 GMT',
      server: 'Kestrel',
      'transfer-encoding': 'chunked',
      'x-moesif-transaction-id': '44f87c27-cbd2-4729-9007-8902fb1bdc22',
      'x-test-header': 'blocked for italy case 1 rule'
    },
    header: {
      connection: 'close',
      date: 'Thu, 02 Nov 2023 22:51:17 GMT',
      server: 'Kestrel',
      'transfer-encoding': 'chunked',
      'x-moesif-transaction-id': '44f87c27-cbd2-4729-9007-8902fb1bdc22',
      'x-test-header': 'blocked for italy case 1 rule'
    },
    statusCode: 403,
    status: 403,
    statusType: 4,
    info: false,
    ok: false,
    redirect: false,
    clientError: true,
    serverError: false,
    error: Error: cannot GET /gov/no_italy (403)
        at Response.toError (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/response.js:110:17)
        at Response._setStatusProperties (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/response-base.js:107:48)
        at new Response (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/response.js:41:8)
        at Request._emitResponse (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:953:20)
        at IncomingMessage.<anonymous> (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:1166:38)
        at IncomingMessage.emit (events.js:412:35)
        at endReadableNT (internal/streams/readable.js:1333:12)
        at processTicksAndRejections (internal/process/task_queues.js:82:21) {
      status: 403,
      text: '{\n  "your_city": "rome",\n  "your_country": "italy"\n}',
      method: 'GET',
      path: '/gov/no_italy'
    },
    created: false,
    accepted: false,
    noContent: false,
    badRequest: false,
    unauthorized: false,
    notAcceptable: false,
    forbidden: true,
    notFound: false,
    unprocessableEntity: false,
    type: '',
    links: {},
    setEncoding: [Function: bound ],
    redirects: [],
    pipe: [Function (anonymous)],
    [Symbol(kCapture)]: false
  }
}
{"connection":"close","date":"Thu, 02 Nov 2023 22:51:17 GMT","server":"Kestrel","transfer-encoding":"chunked","x-moesif-transaction-id":"44f87c27-cbd2-4729-9007-8902fb1bdc22","x-test-header":"blocked for italy case 1 rule"}
response body
{}
    ✔ User in cohort, regex match: apply rule (225ms)
    ✔ User in cohort, regex not match: no apply (273ms)
    ✔ user not in cohort, regex match: no apply (480ms)
    ✔ user not in cohort, regex not match: no apply (258ms)
    ✔ anonymous user, regex match: apply (41ms)
    ✔ anonymous user, regex not match: no apply (173ms)
    ✔ test an company rule not_matching, this one should be not be blocked because in cohort (114ms)
Error: Payment Required
    at Request.callback (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:901:17)
    at IncomingMessage.<anonymous> (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:1166:18)
    at IncomingMessage.emit (events.js:412:35)
    at endReadableNT (internal/streams/readable.js:1333:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  status: 402,
  response: <ref *1> Response {
    _events: [Object: null prototype] {},
    _eventsCount: 0,
    _maxListeners: undefined,
    res: IncomingMessage {
      _readableState: [ReadableState],
      _events: [Object: null prototype],
      _eventsCount: 4,
      _maxListeners: undefined,
      socket: [Socket],
      httpVersionMajor: 1,
      httpVersionMinor: 1,
      httpVersion: '1.1',
      complete: true,
      headers: [Object],
      rawHeaders: [Array],
      trailers: {},
      rawTrailers: [],
      aborted: false,
      upgrade: false,
      url: '',
      method: null,
      statusCode: 402,
      statusMessage: 'Payment Required',
      client: [Socket],
      _consuming: true,
      _dumped: false,
      req: [ClientRequest],
      text: '{\n  "your_company_domain": "{{0}}"\n}',
      [Symbol(kCapture)]: false,
      [Symbol(RequestTimeout)]: undefined
    },
    request: Request {
      _events: [Object: null prototype],
      _eventsCount: 1,
      _maxListeners: undefined,
      _enableHttp2: false,
      _agent: false,
      _formData: null,
      method: 'GET',
      url: 'http://localhost:5001/gov/for_companies_in_japan_only',
      _header: [Object],
      header: [Object],
      writable: true,
      _redirects: 0,
      _maxRedirects: 5,
      cookies: '',
      qs: {},
      _query: [],
      qsRaw: [],
      _redirectList: [],
      _streamRequest: false,
      _lookup: undefined,
      req: [ClientRequest],
      protocol: 'http:',
      host: 'localhost:5001',
      _endCalled: true,
      _callback: [Function (anonymous)],
      _fullfilledPromise: [Promise],
      res: [IncomingMessage],
      _resBuffered: true,
      response: [Circular *1],
      called: true,
      [Symbol(kCapture)]: false
    },
    req: ClientRequest {
      _events: [Object: null prototype],
      _eventsCount: 3,
      _maxListeners: undefined,
      outputData: [],
      outputSize: 0,
      writable: true,
      destroyed: false,
      _last: true,
      chunkedEncoding: false,
      shouldKeepAlive: false,
      _defaultKeepAlive: true,
      useChunkedEncodingByDefault: false,
      sendDate: false,
      _removedConnection: false,
      _removedContLen: false,
      _removedTE: false,
      _contentLength: 0,
      _hasBody: true,
      _trailer: '',
      finished: true,
      _headerSent: true,
      socket: [Socket],
      _header: 'GET /gov/for_companies_in_japan_only HTTP/1.1\r\n' +
        'Host: localhost:5001\r\n' +
        'Accept-Encoding: gzip, deflate\r\n' +
        'X-Company-Id: gov_com_01\r\n' +
        'Connection: close\r\n' +
        '\r\n',
      _keepAliveTimeout: 0,
      _onPendingData: [Function: noopPendingOutput],
      agent: [Agent],
      socketPath: undefined,
      method: 'GET',
      maxHeaderSize: undefined,
      insecureHTTPParser: undefined,
      path: '/gov/for_companies_in_japan_only',
      _ended: true,
      res: [IncomingMessage],
      aborted: false,
      timeoutCb: null,
      upgradeOrConnect: false,
      parser: null,
      maxHeadersCount: null,
      reusedSocket: false,
      host: 'localhost',
      protocol: 'http:',
      [Symbol(kCapture)]: false,
      [Symbol(kNeedDrain)]: false,
      [Symbol(corked)]: 0,
      [Symbol(kOutHeaders)]: [Object: null prototype]
    },
    text: '{\n  "your_company_domain": "{{0}}"\n}',
    files: undefined,
    buffered: true,
    headers: {
      connection: 'close',
      date: 'Thu, 02 Nov 2023 22:51:19 GMT',
      server: 'Kestrel',
      'transfer-encoding': 'chunked',
      'x-moesif-transaction-id': 'ea124517-ff97-4a58-a410-68423f84e259',
      'x-company-block-header': 'companies hq not in japan cohort'
    },
    header: {
      connection: 'close',
      date: 'Thu, 02 Nov 2023 22:51:19 GMT',
      server: 'Kestrel',
      'transfer-encoding': 'chunked',
      'x-moesif-transaction-id': 'ea124517-ff97-4a58-a410-68423f84e259',
      'x-company-block-header': 'companies hq not in japan cohort'
    },
    statusCode: 402,
    status: 402,
    statusType: 4,
    info: false,
    ok: false,
    redirect: false,
    clientError: true,
    serverError: false,
    error: Error: cannot GET /gov/for_companies_in_japan_only (402)
        at Response.toError (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/response.js:110:17)
        at Response._setStatusProperties (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/response-base.js:107:48)
        at new Response (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/response.js:41:8)
        at Request._emitResponse (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:953:20)
        at IncomingMessage.<anonymous> (/Users/xiaokanghuo/dev/governance-rules-tests/node_modules/superagent/src/node/index.js:1166:38)
        at IncomingMessage.emit (events.js:412:35)
        at endReadableNT (internal/streams/readable.js:1333:12)
        at processTicksAndRejections (internal/process/task_queues.js:82:21) {
      status: 402,
      text: '{\n  "your_company_domain": "{{0}}"\n}',
      method: 'GET',
      path: '/gov/for_companies_in_japan_only'
    },
    created: false,
    accepted: false,
    noContent: false,
    badRequest: false,
    unauthorized: false,
    notAcceptable: false,
    forbidden: false,
    notFound: false,
    unprocessableEntity: false,
    type: '',
    links: {},
    setEncoding: [Function: bound ],
    redirects: [],
    pipe: [Function (anonymous)],
    [Symbol(kCapture)]: false
  }
}
    ✔ test an company rule not matching, this one should be blocked since the hq is not in japan (42ms)
    ✔ test an company rule not matching, this one applyed to unindenfied companies also


  9 passing (2s)
