### PR TITLE
Prevent reading the response body if logBody is false

### DIFF
--- a/Moesif.Middleware/NetFramework/Helpers/LoggerHelper.cs
+++ b/Moesif.Middleware/NetFramework/Helpers/LoggerHelper.cs
@@ -133,9 +133,9 @@ namespace Moesif.Middleware.NetFramework.Helpers
             return transactionId;
         }
 
-        public string GetOutputFilterStreamContents(StreamHelper filter, string contentEncoding)
+        public string GetOutputFilterStreamContents(StreamHelper filter, string contentEncoding, bool logBody)
         {
-            if (filter != null)
+            if (logBody && filter != null)
             {
                 return filter.ReadStream(contentEncoding);
             }

--- a/Moesif.Middleware/NetFramework/MoesifMiddlewareNetFramework.cs
+++ b/Moesif.Middleware/NetFramework/MoesifMiddlewareNetFramework.cs
@@ -424,7 +424,7 @@ namespace Moesif.Middleware.NetFramework
             string contentEncoding = "";
             rspHeaders.TryGetValue("Content-Encoding", out contentEncoding);
 
-            var body = loggerHelper.GetOutputFilterStreamContents(outputStream, contentEncoding);            
+            var body = loggerHelper.GetOutputFilterStreamContents(outputStream, contentEncoding, logBody);            
             var bodyWrapper = loggerHelper.Serialize(body, response.ContentType, logBody);
 
             // Add Transaction Id to Response Header


### PR DESCRIPTION
I have no idea if this will work yet but we need some way to prevent reading the response body and this seems like the least invasive way of doing that.

Context: We were testing a new integration (with LogBody* false) that internally generates ~400 MB of response data in the response and this somehow exploded the memory usage when the Moesif middleware was registered (initially 2 GB, up to at least 19 GB with subsequent requests).